### PR TITLE
attemptConversionToDouble

### DIFF
--- a/GBToolbox/NSString+GBToolbox.h
+++ b/GBToolbox/NSString+GBToolbox.h
@@ -32,7 +32,10 @@
 -(int)attemptConversionToInt;
 
 //best attempt to get float out of a string
--(CGFloat)attemptConversionToFloat;
+-(float)attemptConversionToFloat;
+
+//best attempt to get double out of a string
+-(double)attemptConversionToDouble;
 
 //Trims leading and trailing whitespace
 -(NSString *)stringByTrimmingLeadingAndTrailingWhitespace;

--- a/GBToolbox/NSString+GBToolbox.m
+++ b/GBToolbox/NSString+GBToolbox.m
@@ -64,12 +64,17 @@
 }
 
 //best attempt to get float out of a string
--(CGFloat)attemptConversionToFloat {
+-(float)attemptConversionToFloat {
+    return [self attemptConversionToDouble];
+}
+
+//best attempt to get double out of a string
+-(double)attemptConversionToDouble {
     NSString *decimalSeparator = [NSNumberFormatter new].decimalSeparator;
     NSCharacterSet *allowedCharacterSet = [NSCharacterSet characterSetWithCharactersInString:[@"0123456789" stringByAppendingString:decimalSeparator]];
     
     NSString *cleanedPriceString = [self stringByRemovingCharactersNotInSet:allowedCharacterSet];
-    CGFloat rawAmount = [cleanedPriceString floatValue];
+    CGFloat rawAmount = [cleanedPriceString doubleValue];
     
     return rawAmount;
 }


### PR DESCRIPTION
NSString-attemptConversionToFloat returns CGFloat which is confusing because it can be double on 64bit systems.
But actually floatValue is taken from string. So this method always return float precision value even if it is 'wrapped' into a double. So we loose precision on 64bit systems.

I have made small amendments so there are 2 methods now:
-(float)attemptConversionToFloat
-(double)attemptConversionToDouble

This change it is backward compatible because even old call -(CGFloat)attemptConversionToFloat actually returned float or double but always with float precision.
